### PR TITLE
Update ERC 7291 to fix markdown error

### DIFF
--- a/ERCS/erc-7291.md
+++ b/ERCS/erc-7291.md
@@ -13,7 +13,7 @@ requires: 165, 173, 1155
 
 ## Abstract
 
-A Purpose Bound Money (PBM) token is a wrapper around an ERC-1155 token that can be used for a limited activity. This proposal outlines a smart contract interface that builds upon the [ERC-1155](./eip-1155.md) standard to implement the purpose bound money (PBM) concept:
+A Purpose Bound Money (PBM) token is a wrapper around an [ERC-1155](./eip-1155.md) token that can be used for a limited activity. This proposal outlines a smart contract interface that builds upon the ERC-1155 standard to implement the purpose bound money (PBM) concept:
 
 - PBMs is comprised of a PBM wrapper and a digital money token that it wraps. A digital money token (e.g. stablecoins, central bank digital currency, tokenised bank deposits etc) serves as as a store of value (abbreviated as "sov"). Thus, a digital money token (also referred to as "sovToken") **SHOULD** be:
   - a good store of value;


### PR DESCRIPTION
To update to include link in first line of abstract to meet the markdown rule

Run ethereum/eipw-action@be3fa642ec311d0b8e1fdb811e5c9b4ada3d3d93
Error: error[markdown-link-first]: the first match of the given pattern must be a link
  --> ERCS/erc-[7](https://github.com/ethereum/ERCs/actions/runs/14631303133/job/41053956245?pr=887#step:3:8)291.md
   |
16 | A Purpose Bound Money (PBM) token is a wrapper around an ERC-1155 token that can be used for a limited activity. This proposal outli...
   |
   = info: the pattern in question: `(?i)(?:eip|erc)-([0-[9](https://github.com/ethereum/ERCs/actions/runs/14631303133/job/41053956245?pr=887#step:3:10)])+`
   = help: see https://ethereum.github.io/eipw/markdown-link-first/